### PR TITLE
Remove peerDependencies for i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "main": "index.js",
   "repository": "DylanVann/i18next-react-native-language-detector",
   "peerDependencies": {
-    "react-native-locale-detector": "^1.0.0",
-    "i18next": "^3.0.0"
+    "react-native-locale-detector": "^1.0.0"
   }
 }


### PR DESCRIPTION
Remove peerDependencies for i18next as it causes warning for later versions. Current version is 7.1.3